### PR TITLE
quotes,strings fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,10 +90,10 @@ To create a media query that only targets devices with a high pixel density, eit
 ```
 
 ##### `rupture.retina-density`
-Value which controls the minimum density of a device considered to have a retina display. Defaults to 1.5. This value will be used when you call the `retina()` mixin or pass `density: 'retina'` as a keyword argument to any of the width mixins. For example, to target retina tablets, you can do:
+Value which controls the minimum density of a device considered to have a retina display. Defaults to 1.5. This value will be used when you call the `retina()` mixin or pass `density: retina` as a keyword argument to any of the width mixins. For example, to target retina tablets, you can do:
 
 ```js
-+tablet(density: 'retina') // equivalent to +tablet(density: 1.5) unless you change rupture.retina-density
++tablet(density: retina) // equivalent to +tablet(density: 1.5) unless you change rupture.retina-density
 ```
 
 
@@ -139,7 +139,7 @@ When the screen size is between 1050px (defined by `rupture.desktop-cutoff`) and
 When the screen size is 1050px (defined by `rupture.desktop-cutoff`) or more, the styles in the block will take effect.
 
 ##### `+density(value)`
-When the device has a pixel density of at least the given `value`, the styles in the block will take effect. The `value` should be a unitless pixel ratio number such as `1`, `1.5`, or `2`. The `value` can also be the string `'retina'`, in which case the `rupture.retina-density` variable will be used.
+When the device has a pixel density of at least the given `value`, the styles in the block will take effect. The `value` should be a unitless pixel ratio number such as `1`, `1.5`, or `2`. The `value` can also be  `retina`, in which case the `rupture.retina-density` variable will be used.
 
 ##### `+retina()`
 When the device has a pixel density of over `rupture.retina-density` (defaults to 1.5), the styles in the block will take effect.

--- a/rupture/index.styl
+++ b/rupture/index.styl
@@ -12,7 +12,14 @@ rupture = {
 }
 rupture.scale = 0 (rupture.mobile-cutoff) 600px 800px (rupture.desktop-cutoff)
 rupture.scale-names = 'xs' 's' 'm' 'l' 'xl'
-
+-is-string(val)
+  if typeof(val) is not 'unit'
+    if val is a 'string' or val is a 'ident'
+      true
+    else
+      false
+  else
+    false
 -get-scale-number(scale-name)
   for list-item, i in rupture.scale-names
     if list-item is scale-name
@@ -56,6 +63,9 @@ rupture.scale-names = 'xs' 's' 'm' 'l' 'xl'
   return n >= 0
 
 -density-queries(density)
+  if typeof(density) is not 'unit'
+    if not -is-string(density)
+      density = '%s' % density
   density = rupture.retina-density if density is 'retina'
   queries = ()
   for query in rupture.density-queries
@@ -68,6 +78,8 @@ rupture.scale-names = 'xs' 's' 'm' 'l' 'xl'
     else if query is 'ratio'
       push(queries, '(min-device-pixel-ratio: %s)' % (density))
     else if query is 'dpi'
+      if -is-string(density)
+        density=convert(density)
       push(queries, '(min-resolution: %sdpi)' % (round(density * 96, 1)))
     else if query is 'dppx'
       push(queries, '(min-resolution: %sdppx)' % (density))
@@ -83,11 +95,13 @@ rupture.scale-names = 'xs' 's' 'm' 'l' 'xl'
 //   - +between(200px, 4) custom:scale
 
 between(min, max, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
-
-  if typeof(min) is 'string'
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
+  if -is-string(min)
     min = -get-scale-number(min)
-
-  if typeof(max) is 'string'
+  if -is-string(max)
     max = -get-scale-number(max)
 
   -min = rupture.scale[min - 1] unless -is-zero(min) or (not -on-scale(min))
@@ -116,30 +130,54 @@ between(min, max, anti-overlap = rupture.anti-overlap, density = null, orientati
     {block}
 
 at(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +between(scale-point, scale-point, anti-overlap, density, orientation, use-device-width)
     {block}
 
 from(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +between(scale-point, length(rupture.scale), anti-overlap, density, orientation, use-device-width)
     {block}
 
 above = from
 
 to(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +between(1, scale-point, anti-overlap, density, orientation, use-device-width)
     {block}
 
 below = to
 
 mobile(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +below(rupture.mobile-cutoff, anti-overlap, density, orientation, use-device-width)
     {block}
 
 tablet(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +between(rupture.mobile-cutoff, rupture.desktop-cutoff, anti-overlap, density, orientation, use-device-width)
     {block}
 
 desktop(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+  if -is-string(orientation)
+    orientation = convert(orientation)
+  if -is-string(density)
+    density = convert(density)
   +above(rupture.desktop-cutoff, anti-overlap, density, orientation, use-device-width)
     {block}
 
@@ -161,6 +199,8 @@ retina(orientation = null)
     {block}
 
 landscape(density = null)
+  if -is-string(density)
+    density = convert(density)
   if density
     +pixel-ratio(density, orientation: landscape)
       {block}
@@ -169,6 +209,8 @@ landscape(density = null)
       {block}
 
 portrait(density = null)
+  if -is-string(density)
+    density = convert(density)
   if density
     +pixel-ratio(density, orientation: portrait)
       {block}

--- a/test/fixtures/orientation.styl
+++ b/test/fixtures/orientation.styl
@@ -9,7 +9,7 @@ rupture.density-queries = 'webkit' 'dpi'
   +portrait()
     color: maroon
 
-  +above(500px, orientation: landscape)
+  +above(500px, orientation: 'landscape')
     color: lime
 
   +at(2, orientation: portrait)
@@ -27,13 +27,13 @@ rupture.density-queries = 'webkit' 'dpi'
   +from(2, orientation: portrait)
     color: white
 
-  +mobile(orientation: landscape)
+  +mobile(orientation: "landscape")
     color: green
 
-  +tablet(orientation: portrait)
+  +tablet(orientation: 'portrait')
     color: gray
 
-  +to(2, orientation: landscape)
+  +to(2, orientation: 'landscape')
     color: navy
 
   +retina(orientation: portrait)
@@ -45,5 +45,5 @@ rupture.density-queries = 'webkit' 'dpi'
   +density(2, orientation: landscape)
     color: gold
 
-  +landscape(density: 2)
+  +landscape(density: '2')
     color: gold

--- a/test/fixtures/retina.styl
+++ b/test/fixtures/retina.styl
@@ -16,7 +16,7 @@ rupture.retina-density = 2
   +at(2, density: 'retina')
     color: cyan
 
-  +below(500px, density: 'retina')
+  +below(500px, density: retina)
     color: magenta
 
   +between(2, 4, density: 'retina')


### PR DESCRIPTION
I noticed little bug with using strings/literals arguments from #34 

this PR is fixing this behavior when we use density or orientation arguments passed as string or as literals (it converts them to one type in the end). 

And ads a bit more consistent style in readme for this mixins. (i removed quotes, for simplicity of usage)

so we can use 

```
  +mobile(orientation: "landscape")
  +mobile(orientation: landscape)
  +mobile(orientation: 'landscape')
  +landscape(density: '2')
  +landscape(density: 2)
```

will output the same css.

But I didnt touch scale names because they can vary and for example `s` is a `sprintf` stylus bif.
