### PR TITLE
Add -width suffix to `from` and `to`

### DIFF
--- a/rupture/index.styl
+++ b/rupture/index.styl
@@ -137,7 +137,7 @@ at(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation
   +between(scale-point, scale-point, anti-overlap, density, orientation, use-device-width)
     {block}
 
-from(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+from-width(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
   if -is-string(orientation)
     orientation = convert(orientation)
   if -is-string(density)
@@ -145,9 +145,9 @@ from(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientati
   +between(scale-point, length(rupture.scale), anti-overlap, density, orientation, use-device-width)
     {block}
 
-above = from
+above = from-width
 
-to(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
+to-width(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
   if -is-string(orientation)
     orientation = convert(orientation)
   if -is-string(density)
@@ -155,7 +155,7 @@ to(scale-point, anti-overlap = rupture.anti-overlap, density = null, orientation
   +between(1, scale-point, anti-overlap, density, orientation, use-device-width)
     {block}
 
-below = to
+below = to-width
 
 mobile(anti-overlap = rupture.anti-overlap, density = null, orientation = null, use-device-width = rupture.use-device-width)
   if -is-string(orientation)

--- a/test/fixtures/device.styl
+++ b/test/fixtures/device.styl
@@ -1,18 +1,18 @@
 rupture.use-device-width = true
 .device
   color: red
-  +to(2)
+  +to-width(2)
     color: blue
 rupture.use-device-width = false
 .not-device
   color: red
-  +to(2)
+  +to-width(2)
     color: blue
 .device-mixin
   color: red
-  +to(2)
+  +to-width(2)
     color: blue
     content 'max-width'
-  +to(3, use-device-width: true)
+  +to-width(3, use-device-width: true)
     color: blue
     content 'max-device-width'

--- a/test/fixtures/ems.styl
+++ b/test/fixtures/ems.styl
@@ -6,9 +6,9 @@ rupture.enable-em-breakpoints = true
     display: block
   +above(480px)
     display: block
-  +from(500px)
+  +from-width(500px)
     display: block
-  +to(500px)
+  +to-width(500px)
     display: block
   +between(200px, 600px)
     display: block

--- a/test/fixtures/expected/from.css
+++ b/test/fixtures/expected/from.css
@@ -1,4 +1,5 @@
 .hello {
+  background: linear-gradient(from bottom, #f8f8f8, #f4f4f4);
   color: #f00;
 }
 @media only screen and (min-width: 400px) {

--- a/test/fixtures/expected/to.css
+++ b/test/fixtures/expected/to.css
@@ -1,4 +1,5 @@
 .hello {
+  background: linear-gradient(to bottom, #f8f8f8, #f4f4f4);
   color: #f00;
 }
 @media only screen and (max-width: 600px) {

--- a/test/fixtures/from.styl
+++ b/test/fixtures/from.styl
@@ -1,5 +1,6 @@
 .hello
+  background: linear-gradient(from bottom, #F8F8F8, #F4F4F4)
   color: red
 
-  +from(2)
+  +from-width(2)
     color: blue

--- a/test/fixtures/named.styl
+++ b/test/fixtures/named.styl
@@ -7,10 +7,10 @@
   +at('xs')
     color: blue
 
-  +from('m')
+  +from-width('m')
     color: black
 
-  +to('xs')
+  +to-width('xs')
     color: lime
 
   +at('xl')

--- a/test/fixtures/orientation.styl
+++ b/test/fixtures/orientation.styl
@@ -24,7 +24,7 @@ rupture.density-queries = 'webkit' 'dpi'
   +desktop(orientation: landscape)
     color: black
 
-  +from(2, orientation: portrait)
+  +from-width(2, orientation: portrait)
     color: white
 
   +mobile(orientation: "landscape")
@@ -33,7 +33,7 @@ rupture.density-queries = 'webkit' 'dpi'
   +tablet(orientation: 'portrait')
     color: gray
 
-  +to(2, orientation: 'landscape')
+  +to-width(2, orientation: 'landscape')
     color: navy
 
   +retina(orientation: portrait)

--- a/test/fixtures/overlap.styl
+++ b/test/fixtures/overlap.styl
@@ -8,7 +8,7 @@ rupture.anti-overlap = 1px 0.001em 0.001rem
     text-align right
   +at(3)
     text-align left
-    
+
 rupture.anti-overlap = -1px -0.001em -0.001rem
 
 .overlap-minus-em
@@ -27,7 +27,7 @@ rupture.scale = 0 10rem 20rem 800px 1050px
     text-align right
   +at(3)
     text-align left
-    
+
 rupture.anti-overlap = -1px -.001em -.001rem
 .overlap-minus-rem
   text-align center
@@ -35,7 +35,7 @@ rupture.anti-overlap = -1px -.001em -.001rem
     text-align right
   +at(3)
     text-align left
-    
+
 rupture.anti-overlap = 1px .001em .001rem
 rupture.enable-em-breakpoints = false
 rupture.scale = 0 100px 200px 800px 1050px
@@ -45,7 +45,7 @@ rupture.scale = 0 100px 200px 800px 1050px
     text-align right
   +at(3)
     text-align left
-    
+
 rupture.anti-overlap = -1px -.001em -.001rem
 .overlap-minus-px
   text-align center
@@ -60,18 +60,18 @@ rupture.scale = 0 (rupture.mobile-cutoff) 600px 800px (rupture.desktop-cutoff)
 rupture.anti-overlap = false
 rupture.enable-em-breakpoints = false
 
-.overlap-force 
+.overlap-force
   text-align center
   +at(2, anti-overlap: true)
     text-align right
   +at(3, anti-overlap: false)
     text-align left
-  +from(4, anti-overlap: 1px)
+  +from-width(4, anti-overlap: 1px)
     text-align justify
-  +to(4, anti-overlap: 0.0625em)
+  +to-width(4, anti-overlap: 0.0625em)
     border 1px
     content 'we are going max-width, and overlap is positive, so wont change'
-  +from(5, anti-overlap: 0.0625rem)
+  +from-width(5, anti-overlap: 0.0625rem)
     text-align justify
   +tablet(anti-overlap: 1px 0.0625em 0.0625rem)
     font-weight bold
@@ -79,7 +79,7 @@ rupture.enable-em-breakpoints = false
     font-weight normal
   +desktop(anti-overlap: true)
     font-style italic
-    
+
 rupture.enable-em-breakpoints = true
 
 .overlap-force-em
@@ -88,12 +88,12 @@ rupture.enable-em-breakpoints = true
     text-align right
   +at(3, anti-overlap: false)
     text-align left
-  +from(4, anti-overlap: 1px)
+  +from-width(4, anti-overlap: 1px)
     text-align justify
-  +to(4, anti-overlap: 0.0625em)
+  +to-width(4, anti-overlap: 0.0625em)
     border 1px
     content 'we are going max-width, and overlap is positive, so wont change'
-  +from(5, anti-overlap: 0.0625rem)
+  +from-width(5, anti-overlap: 0.0625rem)
     text-align justify
   +tablet(anti-overlap: 1px 0.0625em 0.0625rem)
     font-weight bold

--- a/test/fixtures/retina.styl
+++ b/test/fixtures/retina.styl
@@ -25,7 +25,7 @@ rupture.retina-density = 2
   +desktop(density: 1)
     color: black
 
-  +from(2, density: 1.25)
+  +from-width(2, density: 1.25)
     color: white
 
   +mobile(density: 1.3)
@@ -34,5 +34,5 @@ rupture.retina-density = 2
   +tablet(density: 1.5)
     color: gray
 
-  +to(2, density: 2)
+  +to-width(2, density: 2)
     color: navy

--- a/test/fixtures/to.styl
+++ b/test/fixtures/to.styl
@@ -1,5 +1,6 @@
 .hello
+  background: linear-gradient(to bottom, #F8F8F8, #F4F4F4)
   color: red
 
-  +to(2)
+  +to-width(2)
     color: blue

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -23,10 +23,10 @@ describe 'basic', ->
   it 'at', (done) ->
     match_expected('at.styl', done)
 
-  it 'from', (done) ->
+  it 'from-width', (done) ->
     match_expected('from.styl', done)
 
-  it 'to', (done) ->
+  it 'to-width', (done) ->
     match_expected('to.styl', done)
 
   it 'above', (done) ->
@@ -58,6 +58,6 @@ describe 'basic', ->
 
   it 'supports named scale units', (done) ->
     match_expected('named.styl', done)
-    
+
   it 'supports device-width media queries', (done) ->
     match_expected('device.styl', done)


### PR DESCRIPTION
Fix for #37. I added a `linear-gradient()` in both the `from` and `to` tests. I'm still not sold on `from-width()` and `to-width()`, but I'm not sure what else to call them.
