### PR TITLE
Add index.styl

### DIFF
--- a/index.styl
+++ b/index.styl
@@ -1,0 +1,1 @@
+@import 'rupture/rupture'


### PR DESCRIPTION
Allows you to

`@import rupture` cleanly when installed from npm. This is how other Stylus libraries like nib do it. Otherwise you'd need to do something like `@import node_modules/rupture/lib/rupture` which isn't very pretty.