### PR TITLE
Fix "+rupture-hover" + remove "+hover" alias

### DIFF
--- a/rupture/index.styl
+++ b/rupture/index.styl
@@ -261,7 +261,5 @@ portrait(density = null, fallback-class = null)
 
 rupture-hover(density = null, orientation = null, fallback-class = null)
   condition = "only screen and (hover: hover)";
-  @media ({condition})
+  @media condition
     {block}
-
-hover = rupture-hover


### PR DESCRIPTION
`rupture-hover` was producing this media query:
```css
@media (only screen and (hover: hover)) {
}
```
...which doesn't work cause of the parentheses around the conditions.

But by removing the parentheses in `rupture-hover`, the argument `hover` was replace by `rupture-hover` word in the outputted CSS. I didn't find a way to keep the alias `hover` so I removed it...